### PR TITLE
Fix protractor builder to not move existing e2e scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "peerDependencies": {
     "@angular-devkit/build-angular": "^12.0.0",
+    "@skyux-sdk/e2e": "^4.0.0",
     "codelyzer": "^6.0.0",
     "jasmine-spec-reporter": "^5.0.0",
     "protractor": "^7.0.0",
@@ -32,6 +33,9 @@
     "tslint-jasmine-rules": "^1.6.1"
   },
   "peerDependenciesMeta": {
+    "@skyux-sdk/e2e": {
+      "optional": true
+    },
     "codelyzer": {
       "optional": true
     },

--- a/src/schematics/ng-generate/setup-protractor/setup-protractor.schematic.spec.ts
+++ b/src/schematics/ng-generate/setup-protractor/setup-protractor.schematic.spec.ts
@@ -72,16 +72,6 @@ describe('Setup protractor schematic', () => {
     expect(updatedTree.exists('e2e/src/app.po.ts')).toEqual(true);
   });
 
-  it('should move existing e2e specs to src directory', async () => {
-    tree.create('e2e/foobar.e2e-spec.ts', '');
-    tree.create('e2e/src/foobar-1.e2e-spec.ts', '');
-
-    const updatedTree = await runSchematic();
-
-    expect(updatedTree.exists('e2e/foobar.e2e-spec.ts')).toEqual(false);
-    expect(updatedTree.exists('e2e/src/foobar.e2e-spec.ts')).toEqual(true);
-  });
-
   it('should throw an error if added to library projects', async () => {
     tree = await createTestLibrary(runner, { name: 'my-lib' });
 

--- a/src/schematics/ng-generate/setup-protractor/setup-protractor.schematic.ts
+++ b/src/schematics/ng-generate/setup-protractor/setup-protractor.schematic.ts
@@ -68,16 +68,6 @@ function generateTemplateFiles(options: SetupProtractorSchema): Rule {
   };
 }
 
-function moveExistingE2eSpecs(_options: SetupProtractorSchema): Rule {
-  return (tree) => {
-    tree.getDir('e2e').subfiles.forEach((file) => {
-      if (file.endsWith('.e2e-spec.ts')) {
-        tree.rename(`e2e/${file}`, `e2e/src/${file}`);
-      }
-    });
-  };
-}
-
 export default function setupProtractor(options: SetupProtractorSchema): Rule {
   return (tree, context) => {
     addPackageJsonDependency(tree, {
@@ -104,7 +94,6 @@ export default function setupProtractor(options: SetupProtractorSchema): Rule {
     return chain([
       updateWorkspaceConfig(options),
       generateTemplateFiles(options),
-      moveExistingE2eSpecs(options),
       () => {
         context.addTask(new NodePackageInstallTask());
       }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,10 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "include": [
-    "index.ts",
-    "skyuxconfig-schema.json",
-    "src/**/*.json",
-    "config/**/*.json"
-  ],
+  "include": ["index.ts", "src/**/*.json", "config/**/*.json"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This action will be handled by the `skyux eject` command.